### PR TITLE
Add close function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,17 @@ const DataStore = function (options) {
 util.inherits(DataStore, EventEmitter)
 
 /**
+ * Close the connection to the database, persisting it to disk
+ *
+ * @return {Promise}
+ */
+DataStore.prototype.close = function () {
+  return new Promise((resolve, reject) => {
+    this.database.close(resolve)
+  })
+}
+
+/**
  * Connect to the JSON database file
  *
  * @param {ConnectionOptions} {database, collection}


### PR DESCRIPTION
This PR adds a `.close()` function that forces the database to be persisted to disk.